### PR TITLE
Add documentation for RUM visit exclusion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ Cronitor.load('YOUR_CLIENT_KEY', {
 });
 ```
 
+## Excluding Your Visits from Tracking
+
+To exclude your own visits from being tracked, append `?cronitor_rum_disable` to any page URL on your site:
+
+```
+https://yoursite.com?cronitor_rum_disable
+```
+
+This stores a flag in your browser's `localStorage` that prevents all subsequent tracking on that browser. The exclusion persists across sessions.
+
+To re-enable tracking, visit any page with `?cronitor_rum_enable`:
+
+```
+https://yoursite.com?cronitor_rum_enable
+```
+
 ## Changelog
 
 ### 0.4.1


### PR DESCRIPTION
## Summary
Added documentation for the Real User Monitoring (RUM) visit exclusion feature, allowing users to opt out of tracking their own visits during development and testing.

## Changes
- Added new "Excluding Your Visits from Tracking" section to README.md
- Documented the `?cronitor_rum_disable` query parameter to exclude visits from tracking
- Explained that exclusion is persisted in browser localStorage across sessions
- Documented the `?cronitor_rum_enable` query parameter to re-enable tracking

## Details
This documentation clarifies how developers can prevent their own browsing activity from being tracked by the Cronitor RUM system. Users can simply append the disable parameter to any page URL to opt out, and the setting persists across browser sessions via localStorage. The feature can be toggled back on using the enable parameter.

https://claude.ai/code/session_01DhPYfhbf5o5eLS9mo3FHBt